### PR TITLE
ci: recriar dev a partir de main após merge (quando dev não existir)

### DIFF
--- a/.github/workflows/open-pr-main-to-dev.yml
+++ b/.github/workflows/open-pr-main-to-dev.yml
@@ -25,6 +25,13 @@ jobs:
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
+          # Só sincroniza se a branch dev existir. Se não existir, a recriação
+          # a partir de main é feita pelo workflow recreate-dev-from-main.yml.
+          if ! git ls-remote --exit-code --heads origin dev >/dev/null 2>&1; then
+            echo "A branch 'dev' não existe — recriação tratada por recreate-dev-from-main. A ignorar o sync PR."
+            exit 0
+          fi
+
           existing_pr_number=$(gh pr list \
             --base dev \
             --head main \

--- a/.github/workflows/recreate-dev-from-main.yml
+++ b/.github/workflows/recreate-dev-from-main.yml
@@ -1,0 +1,41 @@
+name: Recreate dev from main
+
+# Após um PR ser mergeado em main (ex.: dev -> main), se a branch `dev` já não
+# existir (foi apagada no merge), recria-a a partir de main. Se `dev` ainda
+# existir, este workflow não faz nada — a sincronização é tratada pelo
+# open-pr-main-to-dev.yml.
+
+on:
+  pull_request:
+    branches:
+      - main
+    types:
+      - closed
+
+permissions:
+  contents: write
+
+jobs:
+  recreate-dev:
+    if: github.event.pull_request.merged == true
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout main
+        uses: actions/checkout@v4
+        with:
+          ref: main
+          fetch-depth: 0
+
+      - name: Recriar dev a partir de main (apenas se não existir)
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          if git ls-remote --exit-code --heads origin dev >/dev/null 2>&1; then
+            echo "A branch 'dev' já existe — nada a fazer (sync tratado por open-pr-main-to-dev)."
+            exit 0
+          fi
+
+          echo "A branch 'dev' não existe. A recriar a partir de main..."
+          git fetch origin main
+          git push origin origin/main:refs/heads/dev
+          echo "Branch 'dev' recriada a partir de main."


### PR DESCRIPTION
## Objetivo
Ativar na `main` a automação de branches: sempre que um PR é mergeado em `main` (ex.: dev → main), garantir que a `dev` fica pronta para o próximo ciclo.

## Mudanças
- **Novo `recreate-dev-from-main.yml`**: se após o merge a branch `dev` **não existir** (foi apagada no merge), recria-a a partir de `main`.
- **Guard em `open-pr-main-to-dev.yml`**: o sync main→dev só corre se a `dev` **existir**.

Os dois workflows ficam **mutuamente exclusivos** (dev existe → sync PR; dev apagada → recriada de main).

> Workflows com trigger `pull_request` só ficam ativos depois de estarem na `main` — daí este PR dedicado (só com os dois ficheiros de workflow), a partir de `main`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)