### PR TITLE
fix(portal,landing): normaliza endereço TomTom, freguesia editável, r…

### DIFF
--- a/packages/landing-page/src/components/landing/RegistrationForm.spec.tsx
+++ b/packages/landing-page/src/components/landing/RegistrationForm.spec.tsx
@@ -1,0 +1,149 @@
+import React from 'react';
+import { fireEvent, render, screen, waitFor } from '@testing-library/react';
+import RegistrationForm from './RegistrationForm';
+
+const TOMTOM_URL = 'https://api.tomtom.test/search/';
+
+const tomtomResponse = (overrides: Record<string, unknown> = {}) => ({
+  ok: true,
+  status: 200,
+  json: async () => ({
+    results: [
+      {
+        address: {
+          streetName: 'Vereda do Alto de Vilar',
+          municipality: 'Maia, Trofa, Vila do Conde',
+          municipalitySubdivision:
+            'Nogueira e Silva Escura, Castêlo da Maia, Barca, Espinhosa, Milheirós, União das Freguesias de Coronado (São Romão e São Mamede)',
+          countrySecondarySubdivision: 'Porto',
+          countrySubdivision: 'Norte',
+          country: 'Portugal',
+          ...overrides,
+        },
+        position: { lat: 41.253486, lon: -8.603952 },
+      },
+    ],
+  }),
+});
+
+const registerResponse = {
+  ok: true,
+  status: 200,
+  json: async () => ({ inServiceZone: true }),
+};
+
+describe('RegistrationForm — normalização do endereço TomTom', () => {
+  const fetchMock = jest.fn();
+
+  beforeEach(() => {
+    fetchMock.mockReset();
+    global.fetch = fetchMock as unknown as typeof fetch;
+    process.env.NEXT_PUBLIC_API_URL = 'https://api.test/';
+    process.env.NEXT_PUBLIC_TOMTOM_API_URL = TOMTOM_URL;
+    process.env.NEXT_PUBLIC_TOMTOM_API_KEY = 'test-key';
+  });
+
+  const registerCall = () =>
+    fetchMock.mock.calls.find((c) => String(c[0]).includes('user/register'));
+
+  const fillRequiredFields = () => {
+    fireEvent.change(screen.getByRole('textbox', { name: /nome/i }), {
+      target: { value: 'José' },
+    });
+    fireEvent.change(screen.getByRole('textbox', { name: /apelido/i }), {
+      target: { value: 'Matos' },
+    });
+    fireEvent.change(screen.getByRole('textbox', { name: /email/i }), {
+      target: { value: 'jose@example.com' },
+    });
+    fireEvent.change(screen.getByRole('textbox', { name: /telemóvel/i }), {
+      target: { value: '911133133' },
+    });
+    fireEvent.change(screen.getByRole('textbox', { name: /morada/i }), {
+      target: { value: 'Vereda do Alto de Vilar' },
+    });
+    fireEvent.change(screen.getByRole('textbox', { name: /porta/i }), {
+      target: { value: '35' },
+    });
+    fireEvent.click(screen.getByRole('radio', { name: /masculino/i }));
+    fireEvent.change(screen.getByLabelText(/data de nascimento/i), {
+      target: { value: '1989-08-25' },
+    });
+  };
+
+  const triggerZipLookup = (value = '4475-390') => {
+    const zip = screen.getByRole('textbox', { name: /código postal/i });
+    fireEvent.change(zip, { target: { value } });
+    fireEvent.blur(zip, { target: { value } });
+  };
+
+  it('guarda apenas a primeira localidade/freguesia da resposta agregada (regressão do 500)', async () => {
+    fetchMock.mockImplementation((url: RequestInfo | URL) =>
+      String(url).includes('tomtom')
+        ? Promise.resolve(tomtomResponse())
+        : Promise.resolve(registerResponse)
+    );
+
+    render(<RegistrationForm />);
+    fillRequiredFields();
+    triggerZipLookup();
+
+    const cityInput = screen.getByRole('textbox', {
+      name: /localidade/i,
+    }) as HTMLInputElement;
+    const divisionInput = screen.getByRole('textbox', {
+      name: /freguesia/i,
+    }) as HTMLInputElement;
+
+    await waitFor(() => expect(cityInput.value).toBe('Maia'));
+    expect(divisionInput.value).toBe('Nogueira e Silva Escura');
+
+    fireEvent.click(screen.getByRole('button', { name: /criar conta/i }));
+
+    await waitFor(() => expect(registerCall()).toBeTruthy());
+
+    const body = JSON.parse(String((registerCall()![1] as RequestInit).body));
+
+    expect(body.address.city).toBe('Maia');
+    expect(body.address.cityDivision).toBe('Nogueira e Silva Escura');
+    expect(body.address.cityDivision.length).toBeLessThanOrEqual(255);
+
+    // Após sucesso, o formulário é limpo.
+    const nomeInput = screen.getByRole('textbox', {
+      name: /nome/i,
+    }) as HTMLInputElement;
+    await waitFor(() => expect(nomeInput.value).toBe(''));
+    expect(cityInput.value).toBe('');
+    expect(divisionInput.value).toBe('');
+  });
+
+  it('permite preencher a freguesia à mão quando a TomTom não a devolve', async () => {
+    fetchMock.mockImplementation((url: RequestInfo | URL) =>
+      String(url).includes('tomtom')
+        ? Promise.resolve(tomtomResponse({ municipalitySubdivision: '' }))
+        : Promise.resolve(registerResponse)
+    );
+
+    render(<RegistrationForm />);
+    fillRequiredFields();
+    triggerZipLookup();
+
+    const divisionInput = screen.getByRole('textbox', {
+      name: /freguesia/i,
+    }) as HTMLInputElement;
+
+    await waitFor(() => expect(divisionInput.value).toBe(''));
+
+    fireEvent.change(divisionInput, { target: { value: 'Águas Santas' } });
+
+    fireEvent.click(screen.getByRole('button', { name: /criar conta/i }));
+
+    await waitFor(() => expect(registerCall()).toBeTruthy());
+
+    const body = JSON.parse(
+      String((registerCall()![1] as RequestInit).body)
+    );
+
+    expect(body.address.cityDivision).toBe('Águas Santas');
+  });
+});

--- a/packages/landing-page/src/components/landing/RegistrationForm.tsx
+++ b/packages/landing-page/src/components/landing/RegistrationForm.tsx
@@ -2,6 +2,7 @@
 
 import { useForm } from 'react-hook-form';
 import { useState } from 'react';
+import { firstAddressPart } from '../../utils/address';
 
 type FormValues = {
   firstName: string;
@@ -32,6 +33,7 @@ export default function RegistrationForm() {
     register,
     handleSubmit,
     setValue,
+    reset,
     formState: { errors },
   } = useForm<FormValues>({
     mode: 'onChange',
@@ -56,7 +58,9 @@ export default function RegistrationForm() {
   });
 
   const [message, setMessage] = useState('');
-  const [messageTone, setMessageTone] = useState<'success' | 'error'>('success');
+  const [messageTone, setMessageTone] = useState<'success' | 'error'>(
+    'success'
+  );
   const [isSubmitting, setIsSubmitting] = useState(false);
 
   const handleBlurZipCode = async (e: React.FocusEvent<HTMLInputElement>) => {
@@ -71,9 +75,14 @@ export default function RegistrationForm() {
       if (!Array.isArray(results) || results.length === 0) return;
       const { address: addr, position } = results[0];
       setValue('street', addr?.streetName ?? '', { shouldValidate: true });
-      setValue('city', addr?.municipality ?? '');
-      setValue('cityDivision', addr?.municipalitySubdivision ?? '');
-      setValue('countryDivision', addr?.countrySecondarySubdivision ?? addr?.countrySubdivision ?? '');
+      setValue('city', firstAddressPart(addr?.municipality));
+      setValue('cityDivision', firstAddressPart(addr?.municipalitySubdivision));
+      setValue(
+        'countryDivision',
+        firstAddressPart(
+          addr?.countrySecondarySubdivision ?? addr?.countrySubdivision
+        )
+      );
       setValue('country', addr?.country ?? '');
       setValue('lat', position?.lat ? String(position.lat) : '');
       setValue('long', position?.lon ? String(position.lon) : '');
@@ -86,30 +95,33 @@ export default function RegistrationForm() {
     setIsSubmitting(true);
     setMessage('');
     try {
-      const res = await fetch(`${process.env.NEXT_PUBLIC_API_URL}user/register`, {
-        method: 'POST',
-        headers: { 'Content-Type': 'application/json' },
-        body: JSON.stringify({
-          firstName: data.firstName,
-          lastName: data.lastName,
-          email: data.email,
-          contactPhone: data.contactPhone,
-          gender: data.gender || undefined,
-          dateOfBirth: data.dateOfBirth || undefined,
-          address: {
-            zipCode: data.zipCode,
-            street: data.street,
-            number: data.number || undefined,
-            complement: data.complement || undefined,
-            city: data.city || undefined,
-            cityDivision: data.cityDivision || undefined,
-            country: data.country || undefined,
-            countryDivision: data.countryDivision || undefined,
-            lat: data.lat || undefined,
-            long: data.long || undefined,
-          },
-        }),
-      });
+      const res = await fetch(
+        `${process.env.NEXT_PUBLIC_API_URL}user/register`,
+        {
+          method: 'POST',
+          headers: { 'Content-Type': 'application/json' },
+          body: JSON.stringify({
+            firstName: data.firstName,
+            lastName: data.lastName,
+            email: data.email,
+            contactPhone: data.contactPhone,
+            gender: data.gender || undefined,
+            dateOfBirth: data.dateOfBirth || undefined,
+            address: {
+              zipCode: data.zipCode,
+              street: data.street,
+              number: data.number || undefined,
+              complement: data.complement || undefined,
+              city: data.city || undefined,
+              cityDivision: data.cityDivision || undefined,
+              country: data.country || undefined,
+              countryDivision: data.countryDivision || undefined,
+              lat: data.lat || undefined,
+              long: data.long || undefined,
+            },
+          }),
+        }
+      );
       if (res.status === 409) {
         setMessageTone('error');
         setMessage('Este email já está registado. Tente fazer login.');
@@ -123,6 +135,7 @@ export default function RegistrationForm() {
           ? 'Registo realizado! Enviámos um email para definir a sua password e ativar a conta. Verifique a sua caixa de entrada.'
           : 'Registo realizado! O seu endereço está fora da zona de atuação — iremos notificá-lo por email assim que estiver disponível.'
       );
+      reset();
     } catch {
       setMessageTone('error');
       setMessage('Erro ao realizar o registo. Tente novamente.');
@@ -134,7 +147,11 @@ export default function RegistrationForm() {
   const req = { required: 'Campo obrigatório' as const };
 
   return (
-    <form className="register-card" onSubmit={handleSubmit(onSubmit)} noValidate>
+    <form
+      className="register-card"
+      onSubmit={handleSubmit(onSubmit)}
+      noValidate
+    >
       <h2 className="register-card-title">Criar conta</h2>
 
       {message ? (
@@ -213,7 +230,9 @@ export default function RegistrationForm() {
             {...register('contactPhone', req)}
           />
           {errors.contactPhone ? (
-            <span className="form-field-error">{errors.contactPhone.message}</span>
+            <span className="form-field-error">
+              {errors.contactPhone.message}
+            </span>
           ) : null}
         </label>
         <label>
@@ -269,7 +288,24 @@ export default function RegistrationForm() {
           <input type="text" {...register('complement')} />
         </label>
       </div>
-
+      <div className="form-row">
+        <label>
+          <span className="form-label">
+            Localidade<span className="form-req">*</span>
+          </span>
+          <input
+            type="text"
+            autoComplete="address-level2"
+            {...register('city')}
+          />
+        </label>
+        <label>
+          <span className="form-label">
+            Freguesia<span className="form-req">*</span>
+          </span>
+          <input type="text" {...register('cityDivision')} />
+        </label>
+      </div>
       <div>
         <span className="form-label">
           Sexo<span className="form-req">*</span>
@@ -307,13 +343,10 @@ export default function RegistrationForm() {
         ) : null}
       </label>
 
-      <input type="hidden" {...register('city')} />
-      <input type="hidden" {...register('cityDivision')} />
       <input type="hidden" {...register('country')} />
       <input type="hidden" {...register('countryDivision')} />
       <input type="hidden" {...register('lat')} />
       <input type="hidden" {...register('long')} />
-
 
       <button type="submit" disabled={isSubmitting}>
         {isSubmitting ? 'A registar…' : 'Criar conta'}
@@ -321,22 +354,57 @@ export default function RegistrationForm() {
 
       <p className="register-login-link">
         Já tens conta?{' '}
-        <a href={portalLoginHref} target="_blank" rel="noopener noreferrer">Login</a>
+        <a href={portalLoginHref} target="_blank" rel="noopener noreferrer">
+          Login
+        </a>
       </p>
 
       <div className="register-social-row" aria-label="Entrar com conta social">
-        <span className="register-social-icon" aria-label="Facebook" role="button" tabIndex={0}>
-          <svg width="16" height="16" viewBox="0 0 24 24" fill="currentColor" aria-hidden="true">
+        <span
+          className="register-social-icon"
+          aria-label="Facebook"
+          role="button"
+          tabIndex={0}
+        >
+          <svg
+            width="16"
+            height="16"
+            viewBox="0 0 24 24"
+            fill="currentColor"
+            aria-hidden="true"
+          >
             <path d="M24 12.073C24 5.405 18.627 0 12 0S0 5.405 0 12.073C0 18.1 4.388 23.094 10.125 24v-8.437H7.078v-3.49h3.047V9.413c0-3.007 1.792-4.669 4.533-4.669 1.312 0 2.686.235 2.686.235v2.953H15.83c-1.491 0-1.956.925-1.956 1.874v2.25h3.328l-.532 3.49h-2.796V24C19.612 23.094 24 18.1 24 12.073z" />
           </svg>
         </span>
-        <span className="register-social-icon" aria-label="Google" role="button" tabIndex={0}>
-          <svg width="16" height="16" viewBox="0 0 24 24" fill="currentColor" aria-hidden="true">
+        <span
+          className="register-social-icon"
+          aria-label="Google"
+          role="button"
+          tabIndex={0}
+        >
+          <svg
+            width="16"
+            height="16"
+            viewBox="0 0 24 24"
+            fill="currentColor"
+            aria-hidden="true"
+          >
             <path d="M12.48 10.92v3.28h7.84c-.24 1.84-.853 3.187-1.787 4.133-1.147 1.147-2.933 2.4-6.053 2.4-4.827 0-8.6-3.893-8.6-8.72s3.773-8.72 8.6-8.72c2.6 0 4.507 1.027 5.907 2.347l2.307-2.307C18.747 1.44 16.133 0 12.48 0 5.867 0 .307 5.387.307 12s5.56 12 12.173 12c3.573 0 6.267-1.173 8.373-3.36 2.16-2.16 2.84-5.213 2.84-7.667 0-.76-.053-1.467-.173-2.053H12.48z" />
           </svg>
         </span>
-        <span className="register-social-icon" aria-label="LinkedIn" role="button" tabIndex={0}>
-          <svg width="16" height="16" viewBox="0 0 24 24" fill="currentColor" aria-hidden="true">
+        <span
+          className="register-social-icon"
+          aria-label="LinkedIn"
+          role="button"
+          tabIndex={0}
+        >
+          <svg
+            width="16"
+            height="16"
+            viewBox="0 0 24 24"
+            fill="currentColor"
+            aria-hidden="true"
+          >
             <path d="M20.447 20.452h-3.554v-5.569c0-1.328-.027-3.037-1.852-3.037-1.853 0-2.136 1.445-2.136 2.939v5.667H9.351V9h3.414v1.561h.046c.477-.9 1.637-1.85 3.37-1.85 3.601 0 4.267 2.37 4.267 5.455v6.286zM5.337 7.433c-1.144 0-2.063-.926-2.063-2.065 0-1.138.92-2.063 2.063-2.063 1.14 0 2.064.925 2.064 2.063 0 1.139-.925 2.065-2.064 2.065zm1.782 13.019H3.555V9h3.564v11.452zM22.225 0H1.771C.792 0 0 .774 0 1.729v20.542C0 23.227.792 24 1.771 24h20.451C23.2 24 24 23.227 24 22.271V1.729C24 .774 23.2 0 22.222 0h.003z" />
           </svg>
         </span>

--- a/packages/landing-page/src/utils/address.spec.ts
+++ b/packages/landing-page/src/utils/address.spec.ts
@@ -1,0 +1,46 @@
+import { firstAddressPart } from './address';
+
+describe('firstAddressPart', () => {
+  it('devolve apenas a primeira localidade de uma string agregada', () => {
+    expect(firstAddressPart('Maia, Trofa, Vila do Conde')).toBe('Maia');
+  });
+
+  it('devolve apenas a primeira freguesia e limita a 255 chars', () => {
+    const freguesias = [
+      'Nogueira e Silva Escura',
+      'Castêlo da Maia',
+      'Barca',
+      'Espinhosa',
+      'Milheirós',
+      'Gondim',
+      'Moreira',
+      'Monte Penedo',
+      'Avioso-São Pedro',
+      'Gemunde',
+      'União das Freguesias de Coronado (São Romão e São Mamede)',
+    ].join(', ');
+
+    const result = firstAddressPart(freguesias);
+
+    expect(result).toBe('Nogueira e Silva Escura');
+    expect(result.length).toBeLessThanOrEqual(255);
+  });
+
+  it('mantém um valor único inalterado', () => {
+    expect(firstAddressPart('Porto')).toBe('Porto');
+  });
+
+  it('faz trim dos espaços à volta da primeira entrada', () => {
+    expect(firstAddressPart('  Lisboa , Sintra ')).toBe('Lisboa');
+  });
+
+  it('devolve string vazia para undefined ou vazio', () => {
+    expect(firstAddressPart(undefined)).toBe('');
+    expect(firstAddressPart('')).toBe('');
+  });
+
+  it('trunca uma primeira entrada com mais de 255 chars', () => {
+    const longFirst = 'A'.repeat(300);
+    expect(firstAddressPart(longFirst).length).toBe(255);
+  });
+});

--- a/packages/landing-page/src/utils/address.ts
+++ b/packages/landing-page/src/utils/address.ts
@@ -1,0 +1,9 @@
+/**
+ * A TomTom Search API devolve `municipality` / `municipalitySubdivision`
+ * concatenados por vírgula para códigos postais que abrangem várias
+ * localidades (ex.: `4475-390` → "Maia, Trofa, Vila do Conde"). Guardar essa
+ * string agregada rebenta a coluna `varchar(255)` do backend. Normalizamos
+ * para a primeira entrada e limitamos a 255 chars por segurança.
+ */
+export const firstAddressPart = (value?: string): string =>
+  (value ?? '').split(',')[0].trim().slice(0, 255);

--- a/packages/portal/src/app/portal/collection-request/collection-request.tsx
+++ b/packages/portal/src/app/portal/collection-request/collection-request.tsx
@@ -18,6 +18,7 @@ import {
 } from '@/components/ui/table';
 import api from '@/lib/api';
 import { isSuccessStatus } from '@/lib/utils';
+import { firstAddressPart } from '@/utils/address';
 import { useAppStore } from '@/store';
 import { MapPinOff } from 'lucide-react';
 import Link from 'next/link';
@@ -177,9 +178,9 @@ export default function CollectionRequest() {
       const { streetName, municipality, countrySubdivision, countrySecondarySubdivision, municipalitySubdivision, country } = address;
       const { setValue, resetField } = adminForm;
       setValue('address.street', streetName ?? '', { shouldDirty: true, shouldTouch: true, shouldValidate: true });
-      setValue('address.cityDivision', municipalitySubdivision ?? '', { shouldDirty: true, shouldTouch: true, shouldValidate: true });
-      setValue('address.city', municipality ?? '', { shouldDirty: true, shouldTouch: true, shouldValidate: true });
-      setValue('address.countryDivision', countrySecondarySubdivision ?? countrySubdivision ?? '', { shouldDirty: true, shouldTouch: true, shouldValidate: true });
+      setValue('address.cityDivision', firstAddressPart(municipalitySubdivision), { shouldDirty: true, shouldTouch: true, shouldValidate: true });
+      setValue('address.city', firstAddressPart(municipality), { shouldDirty: true, shouldTouch: true, shouldValidate: true });
+      setValue('address.countryDivision', firstAddressPart(countrySecondarySubdivision ?? countrySubdivision), { shouldDirty: true, shouldTouch: true, shouldValidate: true });
       setValue('address.zipCode', postalCode, { shouldDirty: true, shouldTouch: true, shouldValidate: true });
       setValue('address.country', country ?? '', { shouldDirty: true, shouldTouch: true, shouldValidate: true });
       const { lat, lon } = position ?? {};

--- a/packages/portal/src/app/portal/package-collection/package-collection.tsx
+++ b/packages/portal/src/app/portal/package-collection/package-collection.tsx
@@ -132,13 +132,14 @@ export default function PackageCollection() {
       throw new Error('Permita pop-ups para imprimir');
     }
 
-    const cards = data
+    // A impressora usa etiquetas de 40x60mm (retrato): um QR code por página/etiqueta.
+    const labels = data
       .map((qr) => {
         const code = escapeHtml(qr.friendlyCode);
-        const qrSource = `https://api.qrserver.com/v1/create-qr-code/?size=180x180&data=${encodeURIComponent(
+        const qrSource = `https://api.qrserver.com/v1/create-qr-code/?size=300x300&margin=0&data=${encodeURIComponent(
           qr.token
         )}`;
-        return `<div class="card"><img src="${qrSource}" alt="QR ${code}" /><div class="code">${code}</div></div>`;
+        return `<div class="label"><img src="${qrSource}" alt="QR ${code}" /><div class="code">${code}</div></div>`;
       })
       .join('');
 
@@ -147,18 +148,29 @@ export default function PackageCollection() {
         <head>
           <title>QR Codes da Rota</title>
           <style>
-            body { margin:0; padding:24px; font-family: Arial, sans-serif; color:#013364; }
-            h1 { font-size:18px; text-align:center; margin:0 0 20px; }
-            .grid { display:grid; grid-template-columns: repeat(auto-fill, minmax(200px, 1fr)); gap:16px; }
-            .card { border:1px solid #cbd5e1; border-radius:10px; padding:12px; text-align:center; }
-            .card img { width:180px; height:180px; object-fit:contain; }
-            .code { margin-top:8px; font-size:15px; font-weight:700; letter-spacing:1px; color:#02748e; }
-            @media print { body { padding:0; } }
+            @page { size: 40mm 60mm; margin: 0; }
+            html, body { margin:0; padding:0; font-family: Arial, sans-serif; color:#013364; }
+            .label {
+              width: 40mm;
+              height: 60mm;
+              box-sizing: border-box;
+              padding: 3mm 2mm;
+              display: flex;
+              flex-direction: column;
+              align-items: center;
+              justify-content: center;
+              gap: 3mm;
+              page-break-after: always;
+              break-after: page;
+            }
+            .label:last-child { page-break-after: auto; break-after: auto; }
+            .label img { width: 34mm; height: 34mm; object-fit: contain; }
+            .code { font-size: 13pt; font-weight:700; letter-spacing:1px; color:#02748e; text-align:center; }
+            @media print { .label { -webkit-print-color-adjust: exact; print-color-adjust: exact; } }
           </style>
         </head>
         <body>
-          <h1>QR Codes da Rota</h1>
-          <div class="grid">${cards}</div>
+          ${labels}
           <script>
             window.onload = function () { window.print(); };
           </script>

--- a/packages/portal/src/app/portal/perfil/address-form.tsx
+++ b/packages/portal/src/app/portal/perfil/address-form.tsx
@@ -7,6 +7,7 @@ import { Checkbox } from '@/components/ui/checkbox';
 import { Label } from '@/components/ui/label';
 import api from '@/lib/api';
 import { isSuccessStatus } from '@/lib/utils';
+import { firstAddressPart } from '@/utils/address';
 import { PlusIcon } from 'lucide-react';
 import { FocusEvent, useCallback, useState } from 'react';
 import { Controller, useForm } from 'react-hook-form';
@@ -76,10 +77,10 @@ export default function AddressForm({ onSave }: Props) {
           setValue(field, val, { shouldDirty: true, shouldTouch: true, shouldValidate: true });
 
         set('street', address.streetName ?? '');
-        set('city', address.municipality ?? '');
-        set('cityDivision', address.municipalitySubdivision ?? '');
+        set('city', firstAddressPart(address.municipality));
+        set('cityDivision', firstAddressPart(address.municipalitySubdivision));
         set('country', address.country ?? '');
-        set('countryDivision', address.countrySecondarySubdivision ?? address.countrySubdivision ?? '');
+        set('countryDivision', firstAddressPart(address.countrySecondarySubdivision ?? address.countrySubdivision));
         setValue('lat', position?.lat ? String(position.lat) : '');
         setValue('long', position?.lon ? String(position.lon) : '');
       } catch {

--- a/packages/portal/src/utils/address.spec.ts
+++ b/packages/portal/src/utils/address.spec.ts
@@ -1,0 +1,41 @@
+import { firstAddressPart } from './address';
+
+describe('firstAddressPart', () => {
+  it('devolve apenas a primeira localidade de uma string agregada', () => {
+    expect(firstAddressPart('Maia, Trofa, Vila do Conde')).toBe('Maia');
+  });
+
+  it('devolve apenas a primeira freguesia e limita a 255 chars', () => {
+    const freguesias = [
+      'Nogueira e Silva Escura',
+      'Castêlo da Maia',
+      'Barca',
+      'Espinhosa',
+      'Milheirós',
+      'União das Freguesias de Coronado (São Romão e São Mamede)',
+    ].join(', ');
+
+    const result = firstAddressPart(freguesias);
+
+    expect(result).toBe('Nogueira e Silva Escura');
+    expect(result.length).toBeLessThanOrEqual(255);
+  });
+
+  it('mantém um valor único inalterado', () => {
+    expect(firstAddressPart('Porto')).toBe('Porto');
+  });
+
+  it('faz trim dos espaços à volta da primeira entrada', () => {
+    expect(firstAddressPart('  Lisboa , Sintra ')).toBe('Lisboa');
+  });
+
+  it('devolve string vazia para undefined ou vazio', () => {
+    expect(firstAddressPart(undefined)).toBe('');
+    expect(firstAddressPart('')).toBe('');
+  });
+
+  it('trunca uma primeira entrada com mais de 255 chars', () => {
+    const longFirst = 'A'.repeat(300);
+    expect(firstAddressPart(longFirst).length).toBe(255);
+  });
+});

--- a/packages/portal/src/utils/address.ts
+++ b/packages/portal/src/utils/address.ts
@@ -1,0 +1,9 @@
+/**
+ * A TomTom Search API devolve `municipality` / `municipalitySubdivision`
+ * concatenados por vírgula para códigos postais que abrangem várias
+ * localidades (ex.: `4475-390` → "Maia, Trofa, Vila do Conde"). Guardar essa
+ * string agregada rebenta a coluna `varchar(255)` do backend. Normalizamos
+ * para a primeira entrada e limitamos a 255 chars por segurança.
+ */
+export const firstAddressPart = (value?: string): string =>
+  (value ?? '').split(',')[0].trim().slice(0, 255);


### PR DESCRIPTION
…eset e etiqueta QR 40x60

- Normaliza os campos agregados da TomTom (municipality / municipalitySubdivision) via firstAddressPart nos forms de registo, perfil e pedido de recolha, evitando strings >255 chars.
- Registo: Localidade e Freguesia passam a inputs editáveis (fallback quando a TomTom não devolve a freguesia) e o form é limpo após sucesso.
- Gerir Recolha: impressão de QR codes em 1 por página, etiqueta 40x60mm (retrato), QR em cima e código por baixo.
- Testes: unit do helper (landing + portal) e integração do RegistrationForm.