### PR TITLE
fix: sacos estimados/recolhidos no dashboard + solicitações sem morada

### DIFF
--- a/packages/portal/src/app/portal/dashboard/dashboard.tsx
+++ b/packages/portal/src/app/portal/dashboard/dashboard.tsx
@@ -249,8 +249,10 @@ export default function Dashboard() {
         />
         <KpiCard
           icon={Boxes}
-          label="Sacos Estimados"
-          value={fmt(collectionRequests.totalBags)}
+          label="Sacos (estimados / recolhidos)"
+          value={`${fmt(collectionRequests.totalEstimatedBags)} / ${fmt(
+            collectionRequests.totalCollectedBags
+          )}`}
         />
         <KpiCard
           icon={Recycle}

--- a/packages/portal/src/app/portal/package-collection/components/collection-map.tsx
+++ b/packages/portal/src/app/portal/package-collection/components/collection-map.tsx
@@ -90,7 +90,7 @@ export default function CollectionMap({
 
       const element = marker.getElement();
       element.style.cursor = 'pointer';
-      element.title = `${pkg.address.street} ${pkg.address.number}`;
+      element.title = `${pkg.address?.street ?? ''} ${pkg.address?.number ?? ''}`;
       element.addEventListener('click', () => onToggleRef.current(pkg.id));
 
       markersRef.current.push(marker);

--- a/packages/portal/src/app/portal/package-collection/package-collection-form.tsx
+++ b/packages/portal/src/app/portal/package-collection/package-collection-form.tsx
@@ -379,7 +379,7 @@ export default function PackageCollectionForm({
   };
 
   const addressLabel = (pkg: CollectionRequestDTO) =>
-    `${pkg.address.street} ${pkg.address.number}`.trim() || '-';
+    `${pkg.address?.street ?? ''} ${pkg.address?.number ?? ''}`.trim() || '-';
 
   const userName = (pkg: CollectionRequestDTO) =>
     `${pkg.user?.firstName ?? ''} ${pkg.user?.lastName ?? ''}`.trim() || '-';
@@ -579,7 +579,7 @@ export default function PackageCollectionForm({
                           <br />
                           {addressLabel(item)}
                         </TableCell>
-                        <TableCell className="whitespace-normal break-words align-top">{item.address.city}</TableCell>
+                        <TableCell className="whitespace-normal break-words align-top">{item.address?.city ?? '-'}</TableCell>
                         <TableCell>{item.estimatedBags ?? '-'}</TableCell>
                       </TableRow>
                     ))
@@ -633,7 +633,7 @@ export default function PackageCollectionForm({
                         </TableCell>
                         <TableCell>{userName(item)}</TableCell>
                         <TableCell>{addressLabel(item)}</TableCell>
-                        <TableCell>{item.address.city}</TableCell>
+                        <TableCell>{item.address?.city ?? '-'}</TableCell>
                         <TableCell>{item.estimatedBags ?? '-'}</TableCell>
                       </TableRow>
                     ))}

--- a/packages/portal/src/app/portal/package-collection/package-collection.tsx
+++ b/packages/portal/src/app/portal/package-collection/package-collection.tsx
@@ -228,8 +228,8 @@ export default function PackageCollection() {
           `${pkg.user.firstName ?? ''} ${pkg.user.lastName ?? ''}`.trim() || '-'
         );
         const address = escapeHtml(
-          `${pkg.address.street ?? ''}, ${pkg.address.number ?? ''} ${
-            pkg.address.city ?? ''
+          `${pkg.address?.street ?? ''}, ${pkg.address?.number ?? ''} ${
+            pkg.address?.city ?? ''
           }`.trim() || '-'
         );
         const code = escapeHtml(pkg.friendlyCode ?? '-');
@@ -252,9 +252,9 @@ export default function PackageCollection() {
         const requesterEmail = escapeHtml(pkg.user.email ?? '-');
         const requesterPhone = escapeHtml(pkg.user.contactPhone ?? '-');
         const fullAddress = escapeHtml(
-          `${pkg.address.street ?? ''}, ${pkg.address.number ?? ''}${
-            pkg.address.complement ? `, ${pkg.address.complement}` : ''
-          }, ${pkg.address.zipCode ?? ''} ${pkg.address.city ?? ''}`
+          `${pkg.address?.street ?? ''}, ${pkg.address?.number ?? ''}${
+            pkg.address?.complement ? `, ${pkg.address?.complement}` : ''
+          }, ${pkg.address?.zipCode ?? ''} ${pkg.address?.city ?? ''}`
             .replace(/\s+,/g, ',')
             .trim() || '-'
         );

--- a/packages/portal/src/app/portal/perfil/perfil.tsx
+++ b/packages/portal/src/app/portal/perfil/perfil.tsx
@@ -127,7 +127,9 @@ export default function Perfil() {
           {
             loading: 'A eliminar...',
             success: 'Endereço eliminado',
-            error: 'Erro ao eliminar endereço',
+            error: (err) =>
+              (err as AxiosError<{ message?: string }>)?.response?.data
+                ?.message ?? 'Erro ao eliminar endereço',
           }
         );
       } finally {

--- a/packages/portal/src/app/types/dashboard.ts
+++ b/packages/portal/src/app/types/dashboard.ts
@@ -3,7 +3,8 @@ import { CollectionRequestStatus } from './collection-request';
 export interface CollectionRequestsStats {
   total: number;
   totalWeightKg: number;
-  totalBags: number;
+  totalEstimatedBags: number;
+  totalCollectedBags: number;
   byStatus: { status: CollectionRequestStatus; count: number }[];
   trend: { period: string; weightKg: number; count: number }[];
 }


### PR DESCRIPTION
## O que muda

### `feat(dashboard)` — Sacos estimados vs. recolhidos
O KPI passa de "Sacos Estimados" para **"Sacos (estimados / recolhidos)"**, exibindo `totalEstimatedBags / totalCollectedBags`.
> Depende do backend correspondente (`develop`): `getTotals()` devolve `totalEstimatedBags` (SUM `estimated_bags`) e `totalCollectedBags` (SUM `bags_generated`).

### `fix(gerir-recolha, perfil)` — Tolerar solicitações sem morada
- **Null-guard `pkg.address?.`** em Gerir Recolha (formulário, impressão da rota, mapa) — corrige o crash **`Cannot read properties of null (reading 'street')`** em solicitações cujo `address_id` aponta para uma morada apagada (soft-delete).
- **Perfil**: ao falhar a eliminação de uma morada, mostra a **mensagem do backend** (ex.: 409 "morada em uso") em vez de um erro genérico. Pareia com o guard no backend (`DeleteAddressUseCase`) que bloqueia eliminar moradas usadas por solicitações ativas.

## Verificação
- `tsc --noEmit` limpo.
- `nx build portal` (anteriormente) OK.

## Notas
- Não inclui a mudança de terminologia da triagem nem o ícone de calças (WIP em curso noutros ficheiros).

🤖 Generated with [Claude Code](https://claude.com/claude-code)