### PR TITLE
fix(portal): revoga a sessão no logout e alinha com a API consolidada

### DIFF
--- a/packages/portal/src/app/portal/blog/[id]/page.tsx
+++ b/packages/portal/src/app/portal/blog/[id]/page.tsx
@@ -1,7 +1,6 @@
 'use client';
 
 import { BlogPostDTO, BlogPostFormData } from '@/app/types/blog';
-import { PaginatedResult } from '@/app/types/helper';
 import api from '@/lib/api';
 import { isSuccessStatus } from '@/lib/utils';
 import { useTranslations } from 'next-intl';
@@ -19,11 +18,10 @@ export default function EditBlogPage() {
 
   const fetchPost = useCallback(async () => {
     try {
-      const { data, status } = await api.get<PaginatedResult<BlogPostDTO>>(
-        '/blog-post?limit=100'
+      const { data: post, status } = await api.get<BlogPostDTO>(
+        `/blog-post/${params.id}`
       );
       if (!isSuccessStatus(status)) throw new Error();
-      const post = data.data.find((p) => p.id === params.id);
       if (!post) {
         toast.error(t('notFound'));
         return;

--- a/packages/portal/src/app/portal/collection-request/collection-request.tsx
+++ b/packages/portal/src/app/portal/collection-request/collection-request.tsx
@@ -128,9 +128,14 @@ export default function CollectionRequest() {
   const fetchRequests = useCallback(async () => {
     try {
       const endpoint = isUserRole ? '/me/collection-requests' : '/collection-request';
-      const { data, status } = await api.get<CollectionRequestDTO[]>(endpoint);
+      // `/me/collection-requests` devolve um array; `/collection-request` é
+      // paginado e devolve `{ data, meta }`.
+      const { data, status } = await api.get<
+        CollectionRequestDTO[] | { data: CollectionRequestDTO[] }
+      >(endpoint);
       if (!isSuccessStatus(status)) throw new Error();
-      setRequests(Array.isArray(data) ? data : []);
+      const list = Array.isArray(data) ? data : data?.data;
+      setRequests(Array.isArray(list) ? list : []);
     } catch {
       toast.error(t('loadError'));
     }

--- a/packages/portal/src/app/portal/storage-unit/storage-unit.tsx
+++ b/packages/portal/src/app/portal/storage-unit/storage-unit.tsx
@@ -10,16 +10,67 @@ import {
   TableRow,
 } from '@/components/ui/table';
 import { PrinterIcon, TrashIcon } from 'lucide-react';
-import { useCallback, useEffect, useState } from 'react';
+import { useCallback, useEffect, useMemo, useState } from 'react';
 import { toast } from 'sonner';
 
 import ConfirmDialog from '@/components/custom/confirmation-dialog';
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from '@/components/ui/select';
 import api from '@/lib/api';
 import { useAppStore } from '@/store';
 import {
+  AgeGroup,
+  Quality,
+  Season,
+  Sex,
   StorageUnitDTO,
+  Type,
 } from '../../types/storage-unit';
 import StorageUnitForm from './storage-unit-form';
+
+// Sentinela do "sem filtro": o Select do shadcn não aceita value="".
+const ALL = 'ALL';
+
+/**
+ * Select de filtro por um atributo de triagem. Os cinco filtros são idênticos
+ * tirando as opções e o tradutor, por isso ficam aqui em vez de repetidos.
+ */
+function FilterSelect({
+  label,
+  allLabel,
+  value,
+  onChange,
+  options,
+  translate,
+}: {
+  label: string;
+  allLabel: string;
+  value: string;
+  onChange: (value: string) => void;
+  options: string[];
+  translate: (key: string) => string;
+}) {
+  return (
+    <Select value={value} onValueChange={onChange}>
+      <SelectTrigger className="w-full sm:w-40" aria-label={label}>
+        <SelectValue placeholder={label} />
+      </SelectTrigger>
+      <SelectContent>
+        <SelectItem value={ALL}>{`${label}: ${allLabel}`}</SelectItem>
+        {options.map((option) => (
+          <SelectItem key={option} value={option}>
+            {translate(option)}
+          </SelectItem>
+        ))}
+      </SelectContent>
+    </Select>
+  );
+}
 
 // Constants
 const escapeHtml = (value: string) =>
@@ -42,6 +93,50 @@ export default function StorageUnit() {
   const { setPageTitle, setBreadcrumbs } = useAppStore();
   const [storageUnits, setStorageUnits] = useState<StorageUnitDTO[]>([]);
   const [isSubmitting, setIsSubmitting] = useState(false);
+
+  // Filtros pelos cinco atributos de triagem — são eles que respondem à
+  // pergunta do operador: "onde ponho uma peça deste tipo?". Filtrados no
+  // cliente, sobre a lista já carregada, como no ecrã de utilizadores.
+  const [qualityFilter, setQualityFilter] = useState<Quality | typeof ALL>(ALL);
+  const [sexFilter, setSexFilter] = useState<Sex | typeof ALL>(ALL);
+  const [ageGroupFilter, setAgeGroupFilter] = useState<AgeGroup | typeof ALL>(ALL);
+  const [typeFilter, setTypeFilter] = useState<Type | typeof ALL>(ALL);
+  const [seasonFilter, setSeasonFilter] = useState<Season | typeof ALL>(ALL);
+
+  const hasFilters =
+    qualityFilter !== ALL ||
+    sexFilter !== ALL ||
+    ageGroupFilter !== ALL ||
+    typeFilter !== ALL ||
+    seasonFilter !== ALL;
+
+  const filteredStorageUnits = useMemo(
+    () =>
+      storageUnits.filter(
+        (unit) =>
+          (qualityFilter === ALL || unit.quality === qualityFilter) &&
+          (sexFilter === ALL || unit.sex === sexFilter) &&
+          (ageGroupFilter === ALL || unit.ageGroup === ageGroupFilter) &&
+          (typeFilter === ALL || unit.type === typeFilter) &&
+          (seasonFilter === ALL || unit.season === seasonFilter)
+      ),
+    [
+      storageUnits,
+      qualityFilter,
+      sexFilter,
+      ageGroupFilter,
+      typeFilter,
+      seasonFilter,
+    ]
+  );
+
+  const clearFilters = useCallback(() => {
+    setQualityFilter(ALL);
+    setSexFilter(ALL);
+    setAgeGroupFilter(ALL);
+    setTypeFilter(ALL);
+    setSeasonFilter(ALL);
+  }, []);
 
   const fetchStorageUnits = useCallback(async () => {
     try {
@@ -200,6 +295,55 @@ export default function StorageUnit() {
   return (
     <section id="storage-unit-page" className="flex flex-col items-center">
       <StorageUnitForm onSave={handleSave} />
+
+      <div className="mt-4 flex w-full flex-wrap items-center gap-2">
+        <FilterSelect
+          label={tCommon('quality')}
+          allLabel={tCommon('all')}
+          value={qualityFilter}
+          onChange={(value) => setQualityFilter(value as Quality | typeof ALL)}
+          options={Object.values(Quality)}
+          translate={tQuality}
+        />
+        <FilterSelect
+          label={tCommon('sex')}
+          allLabel={tCommon('all')}
+          value={sexFilter}
+          onChange={(value) => setSexFilter(value as Sex | typeof ALL)}
+          options={Object.values(Sex)}
+          translate={tSex}
+        />
+        <FilterSelect
+          label={tCommon('ageGroup')}
+          allLabel={tCommon('all')}
+          value={ageGroupFilter}
+          onChange={(value) => setAgeGroupFilter(value as AgeGroup | typeof ALL)}
+          options={Object.values(AgeGroup)}
+          translate={tAgeGroup}
+        />
+        <FilterSelect
+          label={tCommon('part')}
+          allLabel={tCommon('all')}
+          value={typeFilter}
+          onChange={(value) => setTypeFilter(value as Type | typeof ALL)}
+          options={Object.values(Type)}
+          translate={tItemType}
+        />
+        <FilterSelect
+          label={tCommon('season')}
+          allLabel={tCommon('all')}
+          value={seasonFilter}
+          onChange={(value) => setSeasonFilter(value as Season | typeof ALL)}
+          options={Object.values(Season)}
+          translate={tSeason}
+        />
+        {hasFilters && (
+          <Button variant="ghost" onClick={clearFilters}>
+            {tCommon('clear')}
+          </Button>
+        )}
+      </div>
+
       <div className="mt-4 w-full">
         <Table>
           <TableHeader>
@@ -217,8 +361,8 @@ export default function StorageUnit() {
             </TableRow>
           </TableHeader>
           <TableBody>
-            {storageUnits?.length > 0 ? (
-              storageUnits.map((storageUnit) => (
+            {filteredStorageUnits.length > 0 ? (
+              filteredStorageUnits.map((storageUnit) => (
                 <TableRow key={storageUnit.id}>
                   <TableCell className="font-medium">
                     {storageUnit.friendlyCode ?? '-'}

--- a/packages/portal/src/app/portal/triage/components/add-triage.tsx
+++ b/packages/portal/src/app/portal/triage/components/add-triage.tsx
@@ -15,6 +15,7 @@ import {
   TableHeader,
   TableRow,
 } from '@/components/ui/table';
+import { cn } from '@/lib/utils';
 import { Check, TrashIcon, X } from 'lucide-react';
 
 export type TriageListItem = {
@@ -39,6 +40,14 @@ export const buildTriageKey = (attrs: {
   season: string;
 }) =>
   `${attrs.quality}::${attrs.sex}::${attrs.ageGroup}::${attrs.type}::${attrs.season}`;
+
+/**
+ * Linha de item já coberto por uma unidade de armazenamento adicionada.
+ *
+ * O `hover:` não é opcional: o `TableRow` base traz `hover:bg-muted/50`, que
+ * sem isto apagaria o verde ao passar o rato e pareceria avaria.
+ */
+const COVERED_ROW_CLASS = 'bg-green-50 hover:bg-green-100';
 
 type AddTriageProps = {
   items: TriageListItem[];
@@ -155,6 +164,14 @@ export default function AddTriage({
               items.map((item, index) => (
                 <TableRow
                   key={`${item.collectionRequestId}-${item.brandId}-${index}`}
+                  // Verde quando há uma unidade adicionada com os mesmos cinco
+                  // atributos — que é exatamente o critério com que o servidor
+                  // vincula (findCompatibleStorageUnit). Os itens que ficam
+                  // brancos são os que ainda faltam cobrir para poder finalizar.
+                  className={cn(
+                    storageTriageKeys.has(buildTriageKey(item)) &&
+                      COVERED_ROW_CLASS
+                  )}
                 >
                   <TableCell>
                     {tQuality(item.quality) ?? item.quality}

--- a/packages/portal/src/store/auth.ts
+++ b/packages/portal/src/store/auth.ts
@@ -2,7 +2,8 @@
 import { AuthSlice } from '@/app/types/state';
 
 export const createAuthSlice = (
-  set: (state: Partial<AuthSlice>) => void
+  set: (state: Partial<AuthSlice>) => void,
+  get: () => AuthSlice
 ): AuthSlice => ({
   accessToken: null,
   refreshToken: null,
@@ -11,13 +12,27 @@ export const createAuthSlice = (
   setRefreshToken: (t) => set({ refreshToken: t }),
   setUser: (u) => set({ user: u }),
   logout: async () => {
+    // Revogar no servidor ANTES de limpar o estado — é daqui que sai o refresh
+    // token, e sem ele a API não sabe que sessão terminar. Chamada direta (e não
+    // via `lib/api`) para não criar um ciclo de imports store -> api -> store.
+    const refreshToken = get().refreshToken;
+    if (refreshToken) {
+      try {
+        await fetch(`${process.env.NEXT_PUBLIC_API_URL}/auth/logout`, {
+          method: 'POST',
+          headers: { 'Content-Type': 'application/json' },
+          credentials: 'include',
+          body: JSON.stringify({ refresh_token: refreshToken }),
+        });
+      } catch {
+        /* a sessão local termina de qualquer forma */
+      }
+    }
+
     set({ accessToken: null, refreshToken: null, user: null });
     document.cookie = 'retex_session=; max-age=0; path=/; SameSite=Lax';
     document.cookie = 'sidebar_state=; max-age=0; path=/; SameSite=Strict';
     localStorage.removeItem('app-storage');
-    try {
-      await fetch('/auth/logout', { method: 'POST', credentials: 'include' });
-    } catch { /* ignore network errors on logout */ }
     window.location.replace('/auth/login');
   },
 });

--- a/packages/portal/src/store/index.ts
+++ b/packages/portal/src/store/index.ts
@@ -14,7 +14,7 @@ const createStateCreator: StateCreator<
   AppStore
 > = (set, get) => ({
   ...createUiSlice(set),
-  ...createAuthSlice(set),
+  ...createAuthSlice(set, get),
 });
 
 export const useAppStore = create<AppStore>()(


### PR DESCRIPTION
O logout chamava `fetch('/auth/logout')` com URL relativa, batendo na origem do Next em vez da API. Não existe route handler para essa rota, o 404 era engolido pelo `catch {}` e o POST /auth/logout da API — que marca o refresh token como revogado — nunca corria: os tokens sobreviviam ao logout até expirarem. O estado era ainda limpo antes do fetch, pelo que nem com o URL certo haveria token para enviar.

- logout passa a ler o refresh token do store, chamar `${NEXT_PUBLIC_API_URL}/auth/logout` com `{refresh_token}` e só depois limpar a sessão local. Chamada direta (não via `lib/api`) para não criar um ciclo store -> api -> store; a slice recebe agora o `get` do zustand
- o ecrã de edição de post passa a usar GET /blog-post/:id em vez de pedir ?limit=100 e procurar em memória
- a listagem de solicitações trata o envelope paginado de /collection-request, mantendo o array de /me/collection-requests

Verificado: login -> logout devolve 200, is_revoked passa a true na BD e o refresh com esse token passa a 401 (antes devolvia 200).